### PR TITLE
Fixed database syntax error

### DIFF
--- a/updates/builder_table_create_offline_snipcartshop_order_items.php
+++ b/updates/builder_table_create_offline_snipcartshop_order_items.php
@@ -34,10 +34,10 @@ class BuilderTableCreateOfflineSnipcartshopOrderItems extends Migration
             $table->boolean('taxable');
             $table->json('custom_fields');
             $table->json('taxes');
-            $table->timestamp('added_on');
+            $table->timestamp('added_on')->nullable();
         });
     }
-    
+
     public function down()
     {
         Schema::dropIfExists('offline_snipcartshop_order_items');

--- a/updates/builder_table_create_offline_snipcartshop_orders.php
+++ b/updates/builder_table_create_offline_snipcartshop_orders.php
@@ -14,9 +14,9 @@ class BuilderTableCreateOfflineSnipcartshopOrders extends Migration
             $table->uuid('token')->unique();
             $table->string('invoice_number');
             $table->string('currency');
-            $table->timestamp('creation_date');
-            $table->timestamp('modification_date');
-            $table->timestamp('completion_date');
+            $table->timestamp('creation_date')->nullable();
+            $table->timestamp('modification_date')->nullable();
+            $table->timestamp('completion_date')->nullable();
             $table->string('status');
             $table->string('payment_status');
             $table->string('email');
@@ -55,7 +55,7 @@ class BuilderTableCreateOfflineSnipcartshopOrders extends Migration
             $table->uuid('user_id');
         });
     }
-    
+
     public function down()
     {
         Schema::dropIfExists('offline_snipcartshop_orders');


### PR DESCRIPTION
While installing the plugin, the time stamps in `Order` and `Order Item` tables had incorrect default values which have been fixed in this pull request