### PR TITLE
Support money_format function for windows platforms

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -1,21 +1,102 @@
 <?php
-if ( ! function_exists('format_money')) {
-    /**
-     * Formats a price. Adds the currency if provided.
-     *
-     * @param string $value
-     * @param null   $currency
-     *
-     * @return string
-     */
-    function format_money($value, $currency = null)
-    {
-        $number = money_format('%.2n', (float)$value);
+if ( ! function_exists('money_format')) {
 
-        if ($currency) {
-            $number = "${currency} ${number}";
+
+
+/*
+Checks if money_format exist in current platform.
+
+Function accepts the same parameters that the original one accepts.
+
+(Sorry. my writing in English is very bad)
+
+The function is tested using PHP 7.0.9 in Windows 10
+and Apache WebServer.
+*/
+function money_format($format, $number)
+{
+    $regex  = '/%((?:[\^!\-]|\+|\(|\=.)*)([0-9]+)?'.
+              '(?:#([0-9]+))?(?:\.([0-9]+))?([in%])/';
+    if (setlocale(LC_MONETARY, 0) == 'C') {
+        setlocale(LC_MONETARY, '');
+    }
+    $locale = localeconv();
+    preg_match_all($regex, $format, $matches, PREG_SET_ORDER);
+    foreach ($matches as $fmatch) {
+        $value = floatval($number);
+        $flags = array(
+            'fillchar'  => preg_match('/\=(.)/', $fmatch[1], $match) ?
+                           $match[1] : ' ',
+            'nogroup'   => preg_match('/\^/', $fmatch[1]) > 0,
+            'usesignal' => preg_match('/\+|\(/', $fmatch[1], $match) ?
+                           $match[0] : '+',
+            'nosimbol'  => preg_match('/\!/', $fmatch[1]) > 0,
+            'isleft'    => preg_match('/\-/', $fmatch[1]) > 0
+        );
+        $width      = trim($fmatch[2]) ? (int)$fmatch[2] : 0;
+        $left       = trim($fmatch[3]) ? (int)$fmatch[3] : 0;
+        $right      = trim($fmatch[4]) ? (int)$fmatch[4] : $locale['int_frac_digits'];
+        $conversion = $fmatch[5];
+
+        $positive = true;
+        if ($value < 0) {
+            $positive = false;
+            $value  *= -1;
+        }
+        $letter = $positive ? 'p' : 'n';
+
+        $prefix = $suffix = $cprefix = $csuffix = $signal = '';
+
+        $signal = $positive ? $locale['positive_sign'] : $locale['negative_sign'];
+        switch (true) {
+            case $locale["{$letter}_sign_posn"] == 1 && $flags['usesignal'] == '+':
+                $prefix = $signal;
+                break;
+            case $locale["{$letter}_sign_posn"] == 2 && $flags['usesignal'] == '+':
+                $suffix = $signal;
+                break;
+            case $locale["{$letter}_sign_posn"] == 3 && $flags['usesignal'] == '+':
+                $cprefix = $signal;
+                break;
+            case $locale["{$letter}_sign_posn"] == 4 && $flags['usesignal'] == '+':
+                $csuffix = $signal;
+                break;
+            case $flags['usesignal'] == '(':
+            case $locale["{$letter}_sign_posn"] == 0:
+                $prefix = '(';
+                $suffix = ')';
+                break;
+        }
+        if (!$flags['nosimbol']) {
+            $currency = $cprefix .
+                        ($conversion == 'i' ? $locale['int_curr_symbol'] : $locale['currency_symbol']) .
+                        $csuffix;
+        } else {
+            $currency = '';
+        }
+        $space  = $locale["{$letter}_sep_by_space"] ? ' ' : '';
+
+        $value = number_format($value, $right, $locale['mon_decimal_point'],
+                 $flags['nogroup'] ? '' : $locale['mon_thousands_sep']);
+        $value = @explode($locale['mon_decimal_point'], $value);
+
+        $n = strlen($prefix) + strlen($currency) + strlen($value[0]);
+        if ($left > 0 && $left > $n) {
+            $value[0] = str_repeat($flags['fillchar'], $left - $n) . $value[0];
+        }
+        $value = implode($locale['mon_decimal_point'], $value);
+        if ($locale["{$letter}_cs_precedes"]) {
+            $value = $prefix . $currency . $space . $value . $suffix;
+        } else {
+            $value = $prefix . $value . $space . $currency . $suffix;
+        }
+        if ($width > 0) {
+            $value = str_pad($value, $width, $flags['fillchar'], $flags['isleft'] ?
+                     STR_PAD_RIGHT : STR_PAD_LEFT);
         }
 
-        return $number;
+        $format = str_replace($fmatch[0], $value, $format);
     }
+    return $format;
+  }
 }


### PR DESCRIPTION
money_format is not supported in windows platform as per the [PHP website](http://php.net/manual/en/function.money-format.php) ( in the Note section)
This is a work around to add some support.