### PR TITLE
Add single product menu type

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -5,6 +5,7 @@ use OFFLINE\SnipcartShop\Classes\ApiClient;
 use OFFLINE\SnipcartShop\Classes\DiscountApi;
 use OFFLINE\SnipcartShop\Classes\OrderCompleted;
 use OFFLINE\SnipcartShop\Models\Category;
+use OFFLINE\SnipcartShop\Models\Product;
 use System\Classes\PluginBase;
 
 class Plugin extends PluginBase
@@ -91,6 +92,7 @@ class Plugin extends PluginBase
         Event::listen('pages.menuitem.listTypes', function () {
             return [
                 'all-snipcartshop-categories' => trans('offline.snipcartshop::lang.plugin.menu_items.all_categories'),
+                'snipcartshop-product' => trans('offline.snipcartshop::lang.plugin.menu_items.product')
             ];
         });
 
@@ -98,11 +100,17 @@ class Plugin extends PluginBase
             if ($type == 'all-snipcartshop-categories') {
                 return Category::getMenuTypeInfo($type);
             }
+            if ($type == 'snipcartshop-product') {
+                return Product::getMenuTypeInfo($type);
+            }
         });
 
         Event::listen('pages.menuitem.resolveItem', function ($type, $item, $url, $theme) {
             if ($type == 'all-snipcartshop-categories') {
                 return Category::resolveMenuItem($item, $url, $theme);
+            }
+            if ($type == 'snipcartshop-product') {
+                return Product::resolveMenuItem($item, $url, $theme);
             }
         });
     }

--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -25,6 +25,7 @@
         ],
         'menu_items' => [
             'all_categories' => 'Alle Shop-Kategorien',
+            'product' => 'Einzelnes Produkt'
         ],
         'api_settings' => [
             'label' => 'API und Webhooks',

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -25,6 +25,7 @@
         ],
         'menu_items' => [
             'all_categories' => 'All shop categories',
+            'product' => 'Single product'
         ],
         'api_settings' => [
             'label' => 'API and webhooks',

--- a/models/Product.php
+++ b/models/Product.php
@@ -286,7 +286,7 @@ class Product extends Model
             );
         }
 
-        $entryUrl  = Page::url($pageUrl, [[$pageSlug => $product->slug]]);
+        $entryUrl  = Page::url($pageUrl, [$pageSlug => $product->slug]);
 
         $result             = [];
         $result['url']      = $entryUrl;

--- a/models/Product.php
+++ b/models/Product.php
@@ -1,6 +1,8 @@
 <?php namespace OFFLINE\SnipcartShop\Models;
 
+use Cms\Classes\Page;
 use Illuminate\Database\Eloquent\Collection;
+use InvalidArgumentException;
 use Model;
 use October\Rain\Database\Traits\Validation;
 use October\Rain\Exception\ValidationException;
@@ -239,5 +241,57 @@ class Product extends Model
     public function scopePublished($query)
     {
         return $query->where('published', true);
+    }
+
+    /**
+     * Returns the menu type information array for the RainLab.Pages plugin
+     *
+     * @param $type string
+     *
+     * @return array
+     */
+    public static function getMenuTypeInfo($type)
+    {
+        $result = [];
+        if ($type == 'snipcartshop-product') {
+            $result = [
+                'dynamicItems' => false,
+                'references' => self::lists('name', 'id')
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param $item \RainLab\Pages\Classes\MenuItem
+     * @param $url
+     * @param $theme
+     *
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public static function resolveMenuItem($item, $url, $theme)
+    {
+        $product  = self::findOrFail($item->reference);
+
+        $pageSlug = GeneralSettings::get('product_page_slug', 'slug');
+        if ($pageSlug === '') {
+            $pageSlug = 'slug';
+        }
+
+        if ( ! $pageUrl = GeneralSettings::get('product_page')) {
+            throw new InvalidArgumentException(
+                'SnipcartShop: Please select a product page via the backend settings.'
+            );
+        }
+
+        $entryUrl  = Page::url($pageUrl, [[$pageSlug => $product->slug]]);
+
+        $result             = [];
+        $result['url']      = $entryUrl;
+        $result['isActive'] = $entryUrl === $url;
+
+        return $result;
     }
 }


### PR DESCRIPTION
Adds the ability to display single products in the menu.
This is useful for shops with very few products, say five or something like that.